### PR TITLE
Add Glassbox MVP package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,49 @@
 # glassbox
-glassbox: Observe. Understand. Trust your models.
+
+**glassbox** is a developer-first, real-time observability layer for model tuning. It wraps existing hyperparameter search libraries and training pipelines with tracking, dashboards and GPU awareness so you can see, understand and trust model experiments.
+
+## Features
+- Unified `ModelTuner` API for grid, random and Optuna-powered searches
+- Optional Weights & Biases tracking
+- Lightweight dashboard powered by Streamlit/Reflex
+- GPU environment checks and model capability detection
+- Lazy import helpers to keep dependencies optional
+
+## Installation
+```bash
+pip install glassbox
+```
+
+Optional extras can be installed as needed:
+```bash
+pip install glassbox[gpu]      # GPU libraries
+pip install glassbox[wandb]    # Weights & Biases tracking
+pip install glassbox[ui]       # Dashboard UI
+pip install glassbox[optuna]   # Optuna search backend
+```
+
+## Quick start
+```python
+from glassbox import ModelTuner
+from sklearn.linear_model import LogisticRegression
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
+X, y = load_iris(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+mt = ModelTuner(LogisticRegression(max_iter=100), strategy="grid")
+model = mt.search(X_train, y_train)
+print("accuracy", model.score(X_test, y_test))
+```
+
+See [examples/run_xgboost.py](glassbox/examples/run_xgboost.py) for an Optuna-based workflow with optional tracking and dashboard support.
+
+## Testing
+To run the project test suite:
+```bash
+pytest
+```
+
+## License
+Distributed under the terms of the MIT license.

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,0 +1,17 @@
+"""Quickstart demo for ModelTuner."""
+from __future__ import annotations
+
+from sklearn.datasets import load_iris
+from sklearn.linear_model import LogisticRegression
+from sklearn.model_selection import train_test_split
+
+from glassbox import ModelTuner
+
+
+X, y = load_iris(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+tuner = ModelTuner(model=LogisticRegression(max_iter=200), strategy="grid")
+
+best_model = tuner.search(X_train, y_train, time_limit="10s")
+print("Best score:", best_model.score(X_test, y_test))

--- a/glassbox/__init__.py
+++ b/glassbox/__init__.py
@@ -1,0 +1,5 @@
+"""Glassbox package initialization."""
+
+from .core.tuner import ModelTuner
+
+__all__ = ["ModelTuner"]

--- a/glassbox/config/defaults.py
+++ b/glassbox/config/defaults.py
@@ -1,0 +1,11 @@
+"""Default hyperparameter search spaces."""
+
+SEARCH_SPACES = {
+    "XGBClassifier": {
+        "learning_rate": [0.01, 0.1, 0.3],
+        "max_depth": [3, 5, 7],
+    },
+    "LogisticRegression": {
+        "C": [0.01, 0.1, 1, 10],
+    },
+}

--- a/glassbox/core/evaluator.py
+++ b/glassbox/core/evaluator.py
@@ -1,0 +1,9 @@
+"""Model evaluation helpers."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def evaluate(model: Any, X, y) -> float:
+    """Evaluate *model* on the provided data using ``model.score``."""
+    return float(model.score(X, y))

--- a/glassbox/core/search.py
+++ b/glassbox/core/search.py
@@ -1,0 +1,89 @@
+"""Search strategies for hyperparameter tuning."""
+from __future__ import annotations
+
+import itertools
+import random
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List
+
+from .evaluator import evaluate
+from ..utils.lazy_imports import optional_import
+
+
+@dataclass
+class TrialResult:
+    trial_id: int
+    params: Dict[str, Any]
+    metrics: Dict[str, float]
+    duration: float
+
+
+def _iterate_grid(search_space: Dict[str, Iterable[Any]]):
+    keys = list(search_space)
+    for values in itertools.product(*(search_space[k] for k in keys)):
+        yield dict(zip(keys, values))
+
+
+def grid_search(model, X, y, search_space: Dict[str, Iterable[Any]]) -> List[TrialResult]:
+    results: List[TrialResult] = []
+    for i, params in enumerate(_iterate_grid(search_space), 1):
+        trial_model = model.__class__(**{**model.get_params(), **params})
+        start = time.time()
+        trial_model.fit(X, y)
+        score = evaluate(trial_model, X, y)
+        duration = time.time() - start
+        results.append(
+            TrialResult(i, params, {"score": score}, duration)
+        )
+    return results
+
+
+def random_search(
+    model,
+    X,
+    y,
+    search_space: Dict[str, Iterable[Any]],
+    n_trials: int = 10,
+) -> List[TrialResult]:
+    results: List[TrialResult] = []
+    keys = list(search_space)
+    for i in range(1, n_trials + 1):
+        params = {k: random.choice(list(search_space[k])) for k in keys}
+        trial_model = model.__class__(**{**model.get_params(), **params})
+        start = time.time()
+        trial_model.fit(X, y)
+        score = evaluate(trial_model, X, y)
+        duration = time.time() - start
+        results.append(TrialResult(i, params, {"score": score}, duration))
+    return results
+
+
+def optuna_search(
+    model,
+    X,
+    y,
+    search_space: Dict[str, Iterable[Any]],
+    n_trials: int = 10,
+) -> List[TrialResult]:
+    optuna = optional_import("optuna")
+
+    results: List[TrialResult] = []
+
+    def objective(trial):
+        params = {}
+        for name, values in search_space.items():
+            params[name] = trial.suggest_categorical(name, list(values))
+        trial_model = model.__class__(**{**model.get_params(), **params})
+        start = time.time()
+        trial_model.fit(X, y)
+        score = evaluate(trial_model, X, y)
+        duration = time.time() - start
+        results.append(
+            TrialResult(trial.number, params, {"score": score}, duration)
+        )
+        return score
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=n_trials)
+    return results

--- a/glassbox/core/tuner.py
+++ b/glassbox/core/tuner.py
@@ -59,7 +59,8 @@ class ModelTuner:
         if self.tracker:
             self.tracker.finish()
         if self.dashboard:
-            json.dump([r.__dict__ for r in results], open(self.dashboard.state_path, "w"))
+            with open(self.dashboard.state_path, "w") as f:
+                json.dump([r.__dict__ for r in results], f)
         best = max(results, key=lambda r: r.metrics.get("score", 0.0))
         best_model = self.model.__class__(**{**self.model.get_params(), **best.params})
         best_model.fit(X, y)

--- a/glassbox/core/tuner.py
+++ b/glassbox/core/tuner.py
@@ -1,0 +1,66 @@
+"""High-level ModelTuner API."""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from ..config.defaults import SEARCH_SPACES
+from ..tracking.wandb_tracker import WandbTracker
+from ..ui.dashboard import DashboardServer
+from ..utils.gpu import is_gpu_available, supports_gpu
+from .search import (
+    TrialResult,
+    grid_search,
+    optuna_search,
+    random_search,
+)
+
+
+class ModelTuner:
+    """Orchestrates hyperparameter search with optional tracking and UI."""
+
+    def __init__(
+        self,
+        model: Any,
+        strategy: str = "random",
+        tracking: str | None = None,
+        dashboard: bool = False,
+        enable_gpu: bool = False,
+    ) -> None:
+        self.model = model
+        self.strategy = strategy
+        self.search_space = SEARCH_SPACES.get(model.__class__.__name__, {})
+        self.tracker = WandbTracker() if tracking == "wandb" else None
+        self.dashboard = DashboardServer() if dashboard else None
+        self.enable_gpu = enable_gpu
+
+        if enable_gpu:
+            if not is_gpu_available():
+                raise RuntimeError("GPU requested but none detected")
+            if not supports_gpu(model):
+                raise RuntimeError("Model does not appear to support GPU")
+
+    def _run_search(self, X, y) -> list[TrialResult]:
+        if self.strategy == "grid":
+            return grid_search(self.model, X, y, self.search_space)
+        if self.strategy == "optuna":
+            return optuna_search(self.model, X, y, self.search_space)
+        return random_search(self.model, X, y, self.search_space)
+
+    def search(self, X, y, time_limit: str = "10m"):
+        if self.tracker:
+            self.tracker.start({"strategy": self.strategy})
+        if self.dashboard:
+            self.dashboard.run()
+        results = self._run_search(X, y)
+        for res in results:
+            if self.tracker:
+                self.tracker.log(res.trial_id, res.metrics)
+        if self.tracker:
+            self.tracker.finish()
+        if self.dashboard:
+            json.dump([r.__dict__ for r in results], open(self.dashboard.state_path, "w"))
+        best = max(results, key=lambda r: r.metrics.get("score", 0.0))
+        best_model = self.model.__class__(**{**self.model.get_params(), **best.params})
+        best_model.fit(X, y)
+        return best_model

--- a/glassbox/examples/run_xgboost.py
+++ b/glassbox/examples/run_xgboost.py
@@ -1,0 +1,23 @@
+"""Example usage of ModelTuner with XGBoost."""
+from __future__ import annotations
+
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+from xgboost import XGBClassifier
+
+from glassbox import ModelTuner
+
+
+X, y = load_iris(return_X_y=True)
+X_train, X_test, y_train, y_test = train_test_split(X, y)
+
+tuner = ModelTuner(
+    model=XGBClassifier(tree_method="gpu_hist"),
+    strategy="optuna",
+    tracking="wandb",
+    dashboard=True,
+    enable_gpu=True,
+)
+
+best_model = tuner.search(X_train, y_train, time_limit="10m")
+print("Best score:", best_model.score(X_test, y_test))

--- a/glassbox/tracking/wandb_tracker.py
+++ b/glassbox/tracking/wandb_tracker.py
@@ -1,0 +1,26 @@
+"""Weights & Biases tracking integration."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from ..utils.lazy_imports import optional_import
+
+
+class WandbTracker:
+    """Thin wrapper around :mod:`wandb` allowing lazy import."""
+
+    def __init__(self) -> None:
+        self._wandb = optional_import("wandb")
+        self._run = None
+
+    def start(self, config: Dict[str, Any]) -> None:
+        self._run = self._wandb.init(project="glassbox", config=config)
+
+    def log(self, trial_id: int, metrics: Dict[str, float]) -> None:
+        if self._run is None:
+            return
+        self._wandb.log({"trial_id": trial_id, **metrics})
+
+    def finish(self) -> None:
+        if self._run is not None:
+            self._run.finish()

--- a/glassbox/ui/dashboard.py
+++ b/glassbox/ui/dashboard.py
@@ -1,0 +1,55 @@
+"""Simple real-time dashboard using Reflex or Streamlit."""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from typing import Any, List
+
+from ..utils.lazy_imports import optional_import
+
+
+class DashboardServer:
+    """Launch a minimal dashboard visualising trial results.
+
+    The MVP implementation stores shared state in a JSON file on disk.  The
+    dashboard, powered by Reflex or Streamlit, periodically refreshes and
+    displays the leaderboard of trials.
+    """
+
+    def __init__(self, state_path: str = "dashboard_state.json") -> None:
+        self.state_path = state_path
+
+    def _run_streamlit(self) -> None:
+        import streamlit as st
+        import pandas as pd
+        import time
+
+        st.title("Glassbox Dashboard")
+        placeholder = st.empty()
+        while True:
+            if os.path.exists(self.state_path):
+                try:
+                    data = json.load(open(self.state_path))
+                    df = pd.DataFrame(data)
+                    placeholder.dataframe(df)
+                except Exception:
+                    pass
+            time.sleep(1)
+
+    def run(self) -> None:
+        """Start the dashboard in a background thread."""
+        try:
+            optional_import("reflex")  # not used directly in MVP
+            # A real Reflex app would be defined here.
+            # For the MVP we fall back to Streamlit for a lightweight UI.
+        except ImportError:
+            pass
+        try:
+            optional_import("streamlit")
+        except ImportError as exc:
+            raise ImportError(
+                "Install optional dependency via `pip install glassbox[ui]`"
+            ) from exc
+        thread = threading.Thread(target=self._run_streamlit, daemon=True)
+        thread.start()

--- a/glassbox/ui/dashboard.py
+++ b/glassbox/ui/dashboard.py
@@ -30,7 +30,8 @@ class DashboardServer:
         while True:
             if os.path.exists(self.state_path):
                 try:
-                    data = json.load(open(self.state_path))
+                    with open(self.state_path) as f:
+                        data = json.load(f)
                     df = pd.DataFrame(data)
                     placeholder.dataframe(df)
                 except Exception:

--- a/glassbox/utils/gpu.py
+++ b/glassbox/utils/gpu.py
@@ -1,0 +1,35 @@
+"""GPU utilities."""
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_gpu_available() -> bool:
+    """Best-effort check for GPU availability."""
+    try:  # CuPy
+        import cupy  # noqa: F401
+
+        return True
+    except Exception:
+        pass
+    try:  # xgboost GPU build
+        import xgboost
+
+        info = getattr(xgboost, "build_info", lambda: {})()
+        if isinstance(info, dict) and info.get("USE_CUDA", "") == "ON":
+            return True
+    except Exception:
+        pass
+    try:  # lightgbm GPU
+        import lightgbm  # noqa: F401
+
+        return True
+    except Exception:
+        pass
+    return False
+
+
+def supports_gpu(model: Any) -> bool:
+    """Return ``True`` if *model* appears to support GPU execution."""
+    name = model.__class__.__name__.lower()
+    return any(key in name for key in ["xgb", "lgb", "cuda", "gpu"])

--- a/glassbox/utils/gpu.py
+++ b/glassbox/utils/gpu.py
@@ -10,7 +10,7 @@ def is_gpu_available() -> bool:
         import cupy  # noqa: F401
 
         return True
-    except Exception:
+    except ImportError:
         pass
     try:  # xgboost GPU build
         import xgboost

--- a/glassbox/utils/gpu.py
+++ b/glassbox/utils/gpu.py
@@ -18,13 +18,13 @@ def is_gpu_available() -> bool:
         info = getattr(xgboost, "build_info", lambda: {})()
         if isinstance(info, dict) and info.get("USE_CUDA", "") == "ON":
             return True
-    except Exception:
+    except (ImportError, AttributeError):
         pass
     try:  # lightgbm GPU
         import lightgbm  # noqa: F401
 
         return True
-    except Exception:
+    except ImportError:
         pass
     return False
 

--- a/glassbox/utils/lazy_imports.py
+++ b/glassbox/utils/lazy_imports.py
@@ -1,0 +1,16 @@
+"""Utilities for optional imports."""
+from importlib import import_module
+
+
+def optional_import(module_name: str):
+    """Attempt to import *module_name*.
+
+    Raises an informative :class:`ImportError` if the module cannot be imported
+    and hints how to install the optional dependency.
+    """
+    try:
+        return import_module(module_name)
+    except ImportError as exc:
+        raise ImportError(
+            f"Install optional dependency via `pip install glassbox[{module_name}]`"
+        ) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "glassbox"
+version = "0.1.0"
+description = "Real-time observability for model training and hyperparameter tuning"
+authors = [{ name = "Your Name", email = "you@example.com" }]
+dependencies = [
+    "scikit-learn",
+    "numpy",
+    "pandas",
+    "tqdm"
+]
+
+[project.optional-dependencies]
+gpu = ["xgboost", "lightgbm", "cupy"]
+wandb = ["wandb"]
+ui = ["reflex"]
+optuna = ["optuna"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+scikit-learn
+numpy
+pandas
+tqdm
+xgboost
+lightgbm
+wandb
+reflex
+optuna
+streamlit

--- a/tests/TEST_SUITE.MD
+++ b/tests/TEST_SUITE.MD
@@ -1,0 +1,14 @@
+# Test Suite Overview
+
+This directory contains unit tests for the glassbox MVP package.
+
+| Test File | Purpose |
+|-----------|---------|
+| `test_lazy_imports.py` | Validates the optional import helper returns modules or raises informative errors. |
+| `test_gpu.py` | Ensures GPU detection handles missing libraries and that model capability checks work. |
+| `test_evaluator.py` | Confirms evaluation helper returns a valid score from scikit-learn models. |
+| `test_search.py` | Exercises grid and random search strategies and verifies Optuna integration is optional. |
+| `test_tuner.py` | Checks that the high-level `ModelTuner` orchestrates searches and enforces GPU guards. |
+| `test_wandb_tracker.py` | Uses a dummy W&B client to verify tracking calls. |
+| `test_dashboard.py` | Verifies the dashboard server requires the UI dependency. |
+| `test_config.py` | Confirms default search spaces are populated for key models. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on sys.path so `import glassbox` works
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,8 @@
+from glassbox.config.defaults import SEARCH_SPACES
+
+
+def test_search_spaces_present():
+    assert "XGBClassifier" in SEARCH_SPACES
+    assert "LogisticRegression" in SEARCH_SPACES
+    assert "learning_rate" in SEARCH_SPACES["XGBClassifier"]
+    assert "C" in SEARCH_SPACES["LogisticRegression"]

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,13 @@
+import pytest
+
+from glassbox.ui.dashboard import DashboardServer
+
+
+def test_dashboard_requires_streamlit(monkeypatch):
+    monkeypatch.setattr(
+        "glassbox.ui.dashboard.optional_import",
+        lambda name: (_ for _ in ()).throw(ImportError()),
+    )
+    server = DashboardServer()
+    with pytest.raises(ImportError):
+        server.run()

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,12 @@
+from sklearn.linear_model import LogisticRegression
+from sklearn.datasets import load_iris
+
+from glassbox.core.evaluator import evaluate
+
+
+def test_evaluate_returns_float():
+    X, y = load_iris(return_X_y=True)
+    model = LogisticRegression(max_iter=50).fit(X, y)
+    score = evaluate(model, X, y)
+    assert isinstance(score, float)
+    assert 0 <= score <= 1

--- a/tests/test_gpu.py
+++ b/tests/test_gpu.py
@@ -1,0 +1,27 @@
+import builtins
+import pytest
+
+from glassbox.utils.gpu import is_gpu_available, supports_gpu
+
+
+def test_is_gpu_available_false(monkeypatch):
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in ("cupy", "xgboost", "lightgbm"):
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    assert is_gpu_available() is False
+
+
+def test_supports_gpu_name_matching():
+    class XgbModel:
+        pass
+
+    class LinearModel:
+        pass
+
+    assert supports_gpu(XgbModel()) is True
+    assert supports_gpu(LinearModel()) is False

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -1,0 +1,12 @@
+import pytest
+from glassbox.utils.lazy_imports import optional_import
+
+
+def test_optional_import_success():
+    math = optional_import("math")
+    assert math.sqrt(4) == 2
+
+
+def test_optional_import_failure():
+    with pytest.raises(ImportError):
+        optional_import("definitely_missing_module")

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,26 @@
+import pytest
+from sklearn.linear_model import LogisticRegression
+from sklearn.datasets import load_iris
+
+from glassbox.core import search
+
+X, y = load_iris(return_X_y=True)
+MODEL = LogisticRegression(max_iter=50)
+SEARCH_SPACE = {"C": [0.1, 1.0]}
+
+
+def test_grid_search_runs():
+    results = search.grid_search(MODEL, X, y, SEARCH_SPACE)
+    assert len(results) == 2
+    assert all("score" in r.metrics for r in results)
+
+
+def test_random_search_runs():
+    results = search.random_search(MODEL, X, y, SEARCH_SPACE, n_trials=2)
+    assert len(results) == 2
+
+
+def test_optuna_search_requires_optuna(monkeypatch):
+    monkeypatch.setattr(search, "optional_import", lambda name: (_ for _ in ()).throw(ImportError()))
+    with pytest.raises(ImportError):
+        search.optuna_search(MODEL, X, y, SEARCH_SPACE, n_trials=1)

--- a/tests/test_tuner.py
+++ b/tests/test_tuner.py
@@ -1,0 +1,21 @@
+import pytest
+from sklearn.linear_model import LogisticRegression
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
+
+from glassbox import ModelTuner
+from glassbox.core import tuner as tuner_module
+
+
+def test_model_tuner_search():
+    X, y = load_iris(return_X_y=True)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)
+    mt = ModelTuner(LogisticRegression(max_iter=50), strategy="grid")
+    model = mt.search(X_train, y_train)
+    assert model.score(X_test, y_test) >= 0
+
+
+def test_model_tuner_gpu_guard(monkeypatch):
+    monkeypatch.setattr(tuner_module, "is_gpu_available", lambda: False)
+    with pytest.raises(RuntimeError):
+        ModelTuner(LogisticRegression(), enable_gpu=True)

--- a/tests/test_wandb_tracker.py
+++ b/tests/test_wandb_tracker.py
@@ -1,0 +1,42 @@
+from glassbox.tracking.wandb_tracker import WandbTracker
+
+
+class DummyRun:
+    def __init__(self):
+        self.logged = []
+        self.finished = False
+
+    def log(self, data):
+        self.logged.append(data)
+
+    def finish(self):
+        self.finished = True
+
+
+class DummyWandb:
+    def __init__(self):
+        self.run = DummyRun()
+        self.init_called = False
+
+    def init(self, project, config):
+        self.init_called = True
+        self.project = project
+        self.config = config
+        return self.run
+
+    def log(self, data):
+        self.run.log(data)
+
+
+def test_wandb_tracker_integration(monkeypatch):
+    dummy = DummyWandb()
+    monkeypatch.setattr(
+        "glassbox.tracking.wandb_tracker.optional_import", lambda name: dummy
+    )
+    tracker = WandbTracker()
+    tracker.start({"a": 1})
+    tracker.log(1, {"metric": 0.5})
+    tracker.finish()
+    assert dummy.init_called is True
+    assert dummy.run.logged[0]["trial_id"] == 1
+    assert dummy.run.finished is True


### PR DESCRIPTION
## Summary
- scaffold glassbox package with core ModelTuner API, search strategies, helper utilities, and documentation
- add comprehensive unit tests covering optional imports, GPU detection, search strategies, tuner orchestration, tracking, dashboard requirements, and configuration defaults

## Testing
- `python -m compileall -q glassbox`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688d74169560832ba59bc8dec670e49a