### PR TITLE
Add console logging and progress bars when dashboard disabled

### DIFF
--- a/glassbox/core/search.py
+++ b/glassbox/core/search.py
@@ -5,7 +5,11 @@ import itertools
 import random
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List
+import math
+import logging
+from typing import Any, Dict, Iterable, List, Optional
+
+from tqdm.auto import tqdm
 
 from .evaluator import evaluate
 from ..utils.lazy_imports import optional_import
@@ -25,17 +29,37 @@ def _iterate_grid(search_space: Dict[str, Iterable[Any]]):
         yield dict(zip(keys, values))
 
 
-def grid_search(model, X, y, search_space: Dict[str, Iterable[Any]]) -> List[TrialResult]:
+def grid_search(
+    model,
+    X,
+    y,
+    search_space: Dict[str, Iterable[Any]],
+    *,
+    show_progress: bool = False,
+    logger: Optional[logging.Logger] = None,
+) -> List[TrialResult]:
+    space_lists = {k: list(v) for k, v in search_space.items()}
+    total = math.prod(len(v) for v in space_lists.values()) if space_lists else 0
+    iterator = enumerate(_iterate_grid(space_lists), 1)
+    if show_progress:
+        iterator = tqdm(iterator, total=total, desc="Grid Search")
+
     results: List[TrialResult] = []
-    for i, params in enumerate(_iterate_grid(search_space), 1):
+    for i, params in iterator:
         trial_model = model.__class__(**{**model.get_params(), **params})
         start = time.time()
         trial_model.fit(X, y)
         score = evaluate(trial_model, X, y)
         duration = time.time() - start
-        results.append(
-            TrialResult(i, params, {"score": score}, duration)
-        )
+        if logger:
+            logger.info(
+                "Grid trial %s: params=%s score=%.4f duration=%.2fs",
+                i,
+                params,
+                score,
+                duration,
+            )
+        results.append(TrialResult(i, params, {"score": score}, duration))
     return results
 
 
@@ -45,16 +69,31 @@ def random_search(
     y,
     search_space: Dict[str, Iterable[Any]],
     n_trials: int = 10,
+    *,
+    show_progress: bool = False,
+    logger: Optional[logging.Logger] = None,
 ) -> List[TrialResult]:
     results: List[TrialResult] = []
     keys = list(search_space)
-    for i in range(1, n_trials + 1):
+    iterator = range(1, n_trials + 1)
+    if show_progress:
+        iterator = tqdm(iterator, total=n_trials, desc="Random Search")
+
+    for i in iterator:
         params = {k: random.choice(list(search_space[k])) for k in keys}
         trial_model = model.__class__(**{**model.get_params(), **params})
         start = time.time()
         trial_model.fit(X, y)
         score = evaluate(trial_model, X, y)
         duration = time.time() - start
+        if logger:
+            logger.info(
+                "Random trial %s: params=%s score=%.4f duration=%.2fs",
+                i,
+                params,
+                score,
+                duration,
+            )
         results.append(TrialResult(i, params, {"score": score}, duration))
     return results
 
@@ -65,10 +104,14 @@ def optuna_search(
     y,
     search_space: Dict[str, Iterable[Any]],
     n_trials: int = 10,
+    *,
+    show_progress: bool = False,
+    logger: Optional[logging.Logger] = None,
 ) -> List[TrialResult]:
     optuna = optional_import("optuna")
 
     results: List[TrialResult] = []
+    pbar = tqdm(total=n_trials, desc="Optuna Search") if show_progress else None
 
     def objective(trial):
         params = {}
@@ -79,11 +122,21 @@ def optuna_search(
         trial_model.fit(X, y)
         score = evaluate(trial_model, X, y)
         duration = time.time() - start
-        results.append(
-            TrialResult(trial.number, params, {"score": score}, duration)
-        )
+        if logger:
+            logger.info(
+                "Optuna trial %s: params=%s score=%.4f duration=%.2fs",
+                trial.number,
+                params,
+                score,
+                duration,
+            )
+        if pbar:
+            pbar.update(1)
+        results.append(TrialResult(trial.number, params, {"score": score}, duration))
         return score
 
     study = optuna.create_study(direction="maximize")
     study.optimize(objective, n_trials=n_trials)
+    if pbar:
+        pbar.close()
     return results

--- a/glassbox/core/tuner.py
+++ b/glassbox/core/tuner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
 from ..config.defaults import SEARCH_SPACES
@@ -33,6 +34,9 @@ class ModelTuner:
         self.tracker = WandbTracker() if tracking == "wandb" else None
         self.dashboard = DashboardServer() if dashboard else None
         self.enable_gpu = enable_gpu
+        self.logger = logging.getLogger(self.__class__.__name__)
+        if not dashboard:
+            logging.basicConfig(level=logging.INFO)
 
         if enable_gpu:
             if not is_gpu_available():
@@ -40,28 +44,34 @@ class ModelTuner:
             if not supports_gpu(model):
                 raise RuntimeError("Model does not appear to support GPU")
 
-    def _run_search(self, X, y) -> list[TrialResult]:
+    def _run_search(self, X, y, show_progress: bool) -> list[TrialResult]:
+        kwargs = {"show_progress": show_progress, "logger": self.logger if show_progress else None}
         if self.strategy == "grid":
-            return grid_search(self.model, X, y, self.search_space)
+            return grid_search(self.model, X, y, self.search_space, **kwargs)
         if self.strategy == "optuna":
-            return optuna_search(self.model, X, y, self.search_space)
-        return random_search(self.model, X, y, self.search_space)
+            return optuna_search(self.model, X, y, self.search_space, **kwargs)
+        return random_search(self.model, X, y, self.search_space, **kwargs)
 
     def search(self, X, y, time_limit: str = "10m"):
         if self.tracker:
             self.tracker.start({"strategy": self.strategy})
         if self.dashboard:
             self.dashboard.run()
-        results = self._run_search(X, y)
+        show_progress = self.dashboard is None
+        results = self._run_search(X, y, show_progress)
         for res in results:
             if self.tracker:
                 self.tracker.log(res.trial_id, res.metrics)
+            elif show_progress:
+                self.logger.info("Trial %s metrics: %s", res.trial_id, res.metrics)
         if self.tracker:
             self.tracker.finish()
         if self.dashboard:
             with open(self.dashboard.state_path, "w") as f:
                 json.dump([r.__dict__ for r in results], f)
         best = max(results, key=lambda r: r.metrics.get("score", 0.0))
+        if show_progress:
+            self.logger.info("Best trial %s with params %s", best.trial_id, best.params)
         best_model = self.model.__class__(**{**self.model.get_params(), **best.params})
         best_model.fit(X, y)
         return best_model


### PR DESCRIPTION
## Summary
- Add optional TQDM progress bars and per-trial logging to grid, random, and Optuna searches
- Integrate console logging and progress reporting into ModelTuner when the dashboard is off

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e39bb82fc832bb90d23aeddb3a03b