### PR TITLE
Add unified logger and plugin plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 - Unified `ModelTuner` API for grid, random and Optuna-powered searches
 - Optional Weights & Biases tracking
 - Lightweight dashboard powered by Streamlit/Reflex
+- Unified `GlassboxLogger` routing messages to console, W&B, and dashboard
+- Extensible plugin system with lifecycle hooks (e.g., Telegram notifications)
 - GPU environment checks and model capability detection
 - Lazy import helpers to keep dependencies optional
 
@@ -38,6 +40,24 @@ print("accuracy", model.score(X_test, y_test))
 ```
 
 See [examples/run_xgboost.py](glassbox/examples/run_xgboost.py) for an Optuna-based workflow with optional tracking and dashboard support.
+
+## Logging and Plugins
+
+Use the global `logger` to route messages to different destinations and extend training with plugins:
+
+```python
+from glassbox.logger import logger
+from glassbox.plugins.manager import PluginManager
+from glassbox.plugins.knocknotifier import KnockNotifier
+
+plugin_manager = PluginManager()
+plugin_manager.register(KnockNotifier(telegram_token="your-token", chat_id=123456))
+
+logger.log("Training started", to=["console", "wandb"])
+plugin_manager.trigger("on_training_start")
+```
+
+Plugins listen to lifecycle hooks and should avoid blocking training. The included `KnockNotifier` sends a Telegram message when training completes if the `knockknock` package is installed.
 
 ## Testing
 To run the project test suite:

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -6,6 +6,7 @@ from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
 
 from glassbox import ModelTuner
+from glassbox.logger import logger
 
 
 X, y = load_iris(return_X_y=True)
@@ -14,4 +15,4 @@ X_train, X_test, y_train, y_test = train_test_split(X, y)
 tuner = ModelTuner(model=LogisticRegression(max_iter=200), strategy="grid")
 
 best_model = tuner.search(X_train, y_train, time_limit="10s")
-print("Best score:", best_model.score(X_test, y_test))
+logger.log(f"Best score: {best_model.score(X_test, y_test)}")

--- a/glassbox/core/search.py
+++ b/glassbox/core/search.py
@@ -6,13 +6,13 @@ import random
 import time
 from dataclasses import dataclass
 import math
-import logging
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List
 
 from tqdm.auto import tqdm
 
 from .evaluator import evaluate
 from ..utils.lazy_imports import optional_import
+from ..logger import logger
 
 
 @dataclass
@@ -36,7 +36,6 @@ def grid_search(
     search_space: Dict[str, Iterable[Any]],
     *,
     show_progress: bool = False,
-    logger: Optional[logging.Logger] = None,
 ) -> List[TrialResult]:
     space_lists = {k: list(v) for k, v in search_space.items()}
     total = math.prod(len(v) for v in space_lists.values()) if space_lists else 0
@@ -51,14 +50,12 @@ def grid_search(
         trial_model.fit(X, y)
         score = evaluate(trial_model, X, y)
         duration = time.time() - start
-        if logger:
-            logger.info(
-                "Grid trial %s: params=%s score=%.4f duration=%.2fs",
-                i,
-                params,
-                score,
-                duration,
-            )
+        dest = ["console"] if show_progress else ["dashboard"]
+        logger.log(
+            "Grid trial %s: params=%s score=%.4f duration=%.2fs"
+            % (i, params, score, duration),
+            to=dest,
+        )
         results.append(TrialResult(i, params, {"score": score}, duration))
     return results
 
@@ -71,7 +68,6 @@ def random_search(
     n_trials: int = 10,
     *,
     show_progress: bool = False,
-    logger: Optional[logging.Logger] = None,
 ) -> List[TrialResult]:
     results: List[TrialResult] = []
     keys = list(search_space)
@@ -86,14 +82,12 @@ def random_search(
         trial_model.fit(X, y)
         score = evaluate(trial_model, X, y)
         duration = time.time() - start
-        if logger:
-            logger.info(
-                "Random trial %s: params=%s score=%.4f duration=%.2fs",
-                i,
-                params,
-                score,
-                duration,
-            )
+        dest = ["console"] if show_progress else ["dashboard"]
+        logger.log(
+            "Random trial %s: params=%s score=%.4f duration=%.2fs"
+            % (i, params, score, duration),
+            to=dest,
+        )
         results.append(TrialResult(i, params, {"score": score}, duration))
     return results
 
@@ -106,7 +100,6 @@ def optuna_search(
     n_trials: int = 10,
     *,
     show_progress: bool = False,
-    logger: Optional[logging.Logger] = None,
 ) -> List[TrialResult]:
     optuna = optional_import("optuna")
 
@@ -122,14 +115,12 @@ def optuna_search(
         trial_model.fit(X, y)
         score = evaluate(trial_model, X, y)
         duration = time.time() - start
-        if logger:
-            logger.info(
-                "Optuna trial %s: params=%s score=%.4f duration=%.2fs",
-                trial.number,
-                params,
-                score,
-                duration,
-            )
+        dest = ["console"] if show_progress else ["dashboard"]
+        logger.log(
+            "Optuna trial %s: params=%s score=%.4f duration=%.2fs"
+            % (trial.number, params, score, duration),
+            to=dest,
+        )
         if pbar:
             pbar.update(1)
         results.append(TrialResult(trial.number, params, {"score": score}, duration))

--- a/glassbox/core/tuner.py
+++ b/glassbox/core/tuner.py
@@ -2,13 +2,12 @@
 from __future__ import annotations
 
 import json
-import logging
 from typing import Any
 
 from ..config.defaults import SEARCH_SPACES
 from ..tracking.wandb_tracker import WandbTracker
-from ..ui.dashboard import DashboardServer
 from ..utils.gpu import is_gpu_available, supports_gpu
+from ..logger import logger
 from .search import (
     TrialResult,
     grid_search,
@@ -32,17 +31,8 @@ class ModelTuner:
         self.strategy = strategy
         self.search_space = SEARCH_SPACES.get(model.__class__.__name__, {})
         self.tracker = WandbTracker() if tracking == "wandb" else None
-        self.dashboard = DashboardServer() if dashboard else None
+        self.dashboard = dashboard
         self.enable_gpu = enable_gpu
-        self.logger = logging.getLogger(self.__class__.__name__)
-        if not dashboard:
-            if not self.logger.hasHandlers():
-                handler = logging.StreamHandler()
-                handler.setLevel(logging.INFO)
-                formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-                handler.setFormatter(formatter)
-                self.logger.addHandler(handler)
-            self.logger.setLevel(logging.INFO)
 
         if enable_gpu:
             if not is_gpu_available():
@@ -51,7 +41,7 @@ class ModelTuner:
                 raise RuntimeError("Model does not appear to support GPU")
 
     def _run_search(self, X, y, show_progress: bool) -> list[TrialResult]:
-        kwargs = {"show_progress": show_progress, "logger": self.logger if show_progress else None}
+        kwargs = {"show_progress": show_progress}
         if self.strategy == "grid":
             return grid_search(self.model, X, y, self.search_space, **kwargs)
         if self.strategy == "optuna":
@@ -61,23 +51,19 @@ class ModelTuner:
     def search(self, X, y, time_limit: str = "10m"):
         if self.tracker:
             self.tracker.start({"strategy": self.strategy})
-        if self.dashboard:
-            self.dashboard.run()
-        show_progress = self.dashboard is None
+        show_progress = not self.dashboard
         results = self._run_search(X, y, show_progress)
         for res in results:
             if self.tracker:
                 self.tracker.log(res.trial_id, res.metrics)
-            elif show_progress:
-                self.logger.info("Trial %s metrics: %s", res.trial_id, res.metrics)
         if self.tracker:
             self.tracker.finish()
         if self.dashboard:
-            with open(self.dashboard.state_path, "w") as f:
+            with open(logger.state_path, "w") as f:
                 json.dump([r.__dict__ for r in results], f)
         best = max(results, key=lambda r: r.metrics.get("score", 0.0))
         if show_progress:
-            self.logger.info("Best trial %s with params %s", best.trial_id, best.params)
+            logger.log(f"Best trial {best.trial_id} with params {best.params}")
         best_model = self.model.__class__(**{**self.model.get_params(), **best.params})
         best_model.fit(X, y)
         return best_model

--- a/glassbox/examples/run_xgboost.py
+++ b/glassbox/examples/run_xgboost.py
@@ -6,6 +6,7 @@ from sklearn.model_selection import train_test_split
 from xgboost import XGBClassifier
 
 from glassbox import ModelTuner
+from glassbox.logger import logger
 
 
 X, y = load_iris(return_X_y=True)
@@ -20,4 +21,4 @@ tuner = ModelTuner(
 )
 
 best_model = tuner.search(X_train, y_train, time_limit="10m")
-print("Best score:", best_model.score(X_test, y_test))
+logger.log(f"Best score: {best_model.score(X_test, y_test)}")

--- a/glassbox/logger.py
+++ b/glassbox/logger.py
@@ -1,0 +1,86 @@
+"""Unified logging for the Glassbox package."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Iterable, List
+
+
+class GlassboxLogger:
+    """Simple logger that can write to multiple backends."""
+
+    def __init__(
+        self,
+        use_dashboard: bool = False,
+        use_wandb: bool = False,
+        state_path: str = "dashboard_state.json",
+    ) -> None:
+        self.use_dashboard = use_dashboard
+        self.use_wandb = use_wandb
+        self.state_path = state_path
+        self._dashboard_server = None
+
+        if self.use_dashboard:
+            try:  # pragma: no cover - optional dependency
+                from .ui.dashboard import DashboardServer
+
+                self._dashboard_server = DashboardServer(state_path=self.state_path)
+                self._dashboard_server.run()
+            except Exception:  # missing optional deps or runtime error
+                self.use_dashboard = False
+
+    def log(self, message: str, level: str = "info", to: Iterable[str] | None = None) -> None:
+        """Log a message to the selected destinations.
+
+        Parameters
+        ----------
+        message:
+            Text to log.
+        level:
+            Log level as a string. Currently unused but reserved for future
+            enhancements.
+        to:
+            Iterable of destinations. Supported values: ``"console"``,
+            ``"wandb"``, ``"dashboard"``.
+        """
+
+        destinations: List[str] = list(to) if to is not None else ["console"]
+
+        if "console" in destinations:
+            print(message)
+
+        if "wandb" in destinations and self.use_wandb:
+            try:
+                import wandb  # type: ignore
+
+                wandb.log({"message": message, "level": level})
+            except Exception:
+                pass
+
+        if "dashboard" in destinations and self.use_dashboard:
+            self.log_to_dashboard(message, level=level)
+
+    def log_to_dashboard(self, message: str, level: str = "info") -> None:
+        """Persist log messages for the dashboard server.
+
+        Messages are appended to a JSON file that the :class:`DashboardServer`
+        reads and visualises in real time. Any errors are silently ignored so
+        that logging never interrupts training.
+        """
+
+        entry = {"message": message, "level": level}
+        try:
+            data: List[dict] = []
+            if os.path.exists(self.state_path):
+                with open(self.state_path) as f:
+                    existing = json.load(f)
+                    if isinstance(existing, list):
+                        data = existing
+            data.append(entry)
+            with open(self.state_path, "w") as f:
+                json.dump(data, f)
+        except Exception:
+            pass
+
+
+logger = GlassboxLogger(use_dashboard=True, use_wandb=True)

--- a/glassbox/plugins/__init__.py
+++ b/glassbox/plugins/__init__.py
@@ -1,0 +1,6 @@
+"""Plugin system for Glassbox."""
+
+from .base import Plugin
+from .manager import PluginManager
+
+__all__ = ["Plugin", "PluginManager"]

--- a/glassbox/plugins/base.py
+++ b/glassbox/plugins/base.py
@@ -1,0 +1,22 @@
+"""Base class for Glassbox plugins."""
+
+
+class Plugin:
+    """Base plugin class.
+
+    Subclasses can override any of the lifecycle hooks to perform actions
+    during training. Hooks should be non-blocking and avoid mutating model
+    state.
+    """
+
+    def on_training_start(self) -> None:  # pragma: no cover - simple pass methods
+        """Called before training begins."""
+        pass
+
+    def on_training_end(self) -> None:  # pragma: no cover - simple pass methods
+        """Called after training ends."""
+        pass
+
+    def on_epoch_end(self, metrics: dict) -> None:  # pragma: no cover - simple pass methods
+        """Called after each epoch with training metrics."""
+        pass

--- a/glassbox/plugins/knocknotifier.py
+++ b/glassbox/plugins/knocknotifier.py
@@ -1,0 +1,42 @@
+"""KnockNotifier plugin using the knockknock telegram sender."""
+
+from __future__ import annotations
+
+from threading import Thread
+
+from glassbox.plugins.base import Plugin
+from glassbox.logger import logger
+
+try:  # pragma: no cover - optional dependency
+    from knockknock import telegram_sender
+except Exception:  # pragma: no cover - optional dependency
+    telegram_sender = None
+
+
+class KnockNotifier(Plugin):
+    """Send a notification when training completes."""
+
+    def __init__(self, telegram_token: str, chat_id: int) -> None:
+        self.telegram_token = telegram_token
+        self.chat_id = chat_id
+
+    def on_training_end(self) -> None:
+        logger.log("KnockNotifier: Training complete", to=["console"])
+        self._notify("✅ Glassbox training finished!")
+
+    def _notify(self, msg: str) -> None:
+        """Dispatch the telegram notification in a background thread."""
+
+        if telegram_sender is None:
+            logger.log("KnockNotifier: knockknock not installed", to=["console"])
+            return
+
+        def send() -> None:
+            try:
+                send_fn = telegram_sender(token=self.telegram_token, chat_id=self.chat_id)
+                decorated = send_fn(lambda: None)
+                decorated()
+            except Exception as exc:  # pragma: no cover - network/telegram errors
+                logger.log(f"KnockNotifier error: {exc}", to=["console"])
+
+        Thread(target=send, daemon=True).start()

--- a/glassbox/plugins/manager.py
+++ b/glassbox/plugins/manager.py
@@ -1,0 +1,19 @@
+"""Plugin manager for coordinating plugin hooks."""
+
+
+class PluginManager:
+    """Registers and dispatches events to plugins."""
+
+    def __init__(self) -> None:
+        self.plugins = []
+
+    def register(self, plugin: "Plugin") -> None:
+        """Register a plugin instance."""
+        self.plugins.append(plugin)
+
+    def trigger(self, hook_name: str, **kwargs) -> None:
+        """Trigger a hook on all registered plugins."""
+        for plugin in self.plugins:
+            method = getattr(plugin, hook_name, None)
+            if callable(method):
+                method(**kwargs)

--- a/tests/TEST_SUITE.MD
+++ b/tests/TEST_SUITE.MD
@@ -12,3 +12,5 @@ This directory contains unit tests for the glassbox MVP package.
 | `test_wandb_tracker.py` | Uses a dummy W&B client to verify tracking calls. |
 | `test_dashboard.py` | Verifies the dashboard server requires the UI dependency. |
 | `test_config.py` | Confirms default search spaces are populated for key models. |
+| `test_logger.py` | Checks the unified logger routes messages to console and dashboard. |
+| `test_plugins.py` | Ensures plugin hooks execute and the KnockNotifier handles missing dependencies. |

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,21 @@
+import json
+from glassbox.logger import GlassboxLogger
+
+
+def test_console_logging(capsys):
+    logger = GlassboxLogger(use_dashboard=False, use_wandb=False)
+    logger.log("hello", to=["console"])
+    captured = capsys.readouterr()
+    assert "hello" in captured.out
+
+
+def test_dashboard_logging(tmp_path):
+    logger = GlassboxLogger(use_dashboard=False, use_wandb=False)
+    state_file = tmp_path / "state.json"
+    logger.state_path = str(state_file)
+    logger.use_dashboard = True
+    logger.log("dash", to=["dashboard"])
+    assert state_file.exists()
+    with open(state_file) as f:
+        data = json.load(f)
+    assert data[0]["message"] == "dash"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,25 @@
+from glassbox.plugins.base import Plugin
+from glassbox.plugins.manager import PluginManager
+from glassbox.plugins import knocknotifier
+
+
+def test_plugin_manager_triggers_hooks():
+    class Dummy(Plugin):
+        def __init__(self):
+            self.started = False
+        def on_training_start(self):
+            self.started = True
+    pm = PluginManager()
+    dummy = Dummy()
+    pm.register(dummy)
+    pm.trigger("on_training_start")
+    assert dummy.started
+
+
+def test_knocknotifier_handles_missing_dependency(monkeypatch, capsys):
+    monkeypatch.setattr(knocknotifier, "telegram_sender", None)
+    notifier = knocknotifier.KnockNotifier("token", 123)
+    notifier.on_training_end()
+    out = capsys.readouterr().out
+    assert "Training complete" in out
+    assert "not installed" in out

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -24,3 +24,10 @@ def test_optuna_search_requires_optuna(monkeypatch):
     monkeypatch.setattr(search, "optional_import", lambda name: (_ for _ in ()).throw(ImportError()))
     with pytest.raises(ImportError):
         search.optuna_search(MODEL, X, y, SEARCH_SPACE, n_trials=1)
+
+
+def test_grid_search_logs_to_dashboard(monkeypatch):
+    calls = []
+    monkeypatch.setattr(search.logger, "log", lambda msg, level="info", to=None: calls.append(to))
+    search.grid_search(MODEL, X, y, SEARCH_SPACE)
+    assert calls and calls[0] == ["dashboard"]

--- a/tests/test_tuner.py
+++ b/tests/test_tuner.py
@@ -19,3 +19,14 @@ def test_model_tuner_gpu_guard(monkeypatch):
     monkeypatch.setattr(tuner_module, "is_gpu_available", lambda: False)
     with pytest.raises(RuntimeError):
         ModelTuner(LogisticRegression(), enable_gpu=True)
+
+
+def test_model_tuner_writes_dashboard_state(tmp_path, monkeypatch):
+    X, y = load_iris(return_X_y=True)
+    X_train, _, y_train, _ = train_test_split(X, y, random_state=0)
+    state_file = tmp_path / "state.json"
+    monkeypatch.setattr(tuner_module.logger, "state_path", str(state_file))
+    monkeypatch.setattr(tuner_module.logger, "use_dashboard", True)
+    mt = ModelTuner(LogisticRegression(max_iter=50), strategy="grid", dashboard=True)
+    mt.search(X_train, y_train)
+    assert state_file.exists()


### PR DESCRIPTION
## Summary
- add `GlassboxLogger` for console, W&B, and dashboard logging
- implement lightweight plugin framework with base class and manager
- add `KnockNotifier` plugin using knockknock telegram sender
- integrate dashboard server into logger for real-time UI updates
- refactor core search/tuner modules and examples to use the unified logger
- document logger and plugin usage in README
- add tests for logger, plugin manager, search logging, and tuner dashboard output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891eb5667e4832bae5ba8e24914c5f6